### PR TITLE
Skip installation of nodejs on FC machines

### DIFF
--- a/templates/custom.cfg
+++ b/templates/custom.cfg
@@ -1,6 +1,7 @@
 [run-maildev]
 {% if is_flyingcircus.rc == 0 %}
-executable=/run/current-system/sw/bin/node ${buildout:directory}/parts/maildev/bin/maildev
+=>
+executable=npx maildev
 {% endif -%}
 flags= \
     --smtp 8025 \


### PR DESCRIPTION
~~We don't use it anyway, and the build fails on the latest platform~~

Changed to use `npx maildev`. gp.recipe.node doesn't work on Python 3.13

Follow up ticket: https://github.com/syslabcom/scrum/issues/3938

Refs: https://github.com/syslabcom/scrum/issues/3902