### PR TITLE
Fix variable quoting

### DIFF
--- a/templates/maildev.j2
+++ b/templates/maildev.j2
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-export MAILDEV_SMTP_PORT="{{ maildev_smtp_port }}"
+export MAILDEV_SMTP_PORT={{ maildev_smtp_port | quote }}
 export MAILDEV_WEB_PORT=8026
-export MAILDEV_WEB_USER="{{ maildev_username }}"
-export MAILDEV_WEB_PASS="{{ maildev_password }}"
-export MAILDEV_BASE_PATHNAME="{{ maildev_base_pathname }}"
+export MAILDEV_WEB_USER={{ maildev_username }}
+export MAILDEV_WEB_PASS={{ maildev_password | quote }}
+export MAILDEV_BASE_PATHNAME={{ maildev_base_pathname | quote }}
 
 npx maildev


### PR DESCRIPTION
Prevents issues when the replaced variable contains something like a `"` or a `\`

Refs. https://github.com/syslabcom/scrum/issues/3938