### PR TITLE
Install pre-reqs and remove blocking prompt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,16 @@
     - maildev
     - always
 
+- name: Ensure npx is installed
+  ansible.builtin.package:
+    name: npm
+    state: present
+  become: true
+  become_user: root
+  when: not is_flyingcircus | bool
+  tags:
+    - maildev
+
 - name: Cleanup legacy maildev installation
   block:
     - name: Check for legacy $HOME/maildev directory

--- a/templates/maildev.j2
+++ b/templates/maildev.j2
@@ -6,4 +6,4 @@ export MAILDEV_WEB_USER={{ maildev_username }}
 export MAILDEV_WEB_PASS={{ maildev_password | quote }}
 export MAILDEV_BASE_PATHNAME={{ maildev_base_pathname | quote }}
 
-npx maildev
+npx --yes maildev


### PR DESCRIPTION
- install npm as it's missing on machines such as `lorax-quaivedemo` ([not needed for FC nix machines](https://github.com/syslabcom/quaivesaas.ansible/blob/12a41c3fe9e2f6490609e9b3ecc07e85b4552c08/roles/bootstrap/templates/custom.nix#L68))
- add --yes to `npx maildev` so it doesn't prompt block Ansible

Refs. https://github.com/syslabcom/scrum/issues/4922